### PR TITLE
Add a --resolver option.

### DIFF
--- a/src/cabal2stack.hs
+++ b/src/cabal2stack.hs
@@ -99,7 +99,7 @@ optsP = do
         O.flag' False (O.long "no-allow-newer" <> O.help "Don't include allow-newer: True") <|>
         pure False
 
-    optsResolver <- optional $ O.strOption (O.long "resolver" <> O.metavar "[LTS-version | nighly-yyyy-mm-dd]" <> O.help "Use provided resolver")
+    optsResolver <- optional $ O.strOption (O.long "resolver" <> O.metavar "[LTS-version | nighlty-yyyy-mm-dd]" <> O.help "Use provided resolver")
 
     optsPlanJson <- optional $ O.strOption (O.long "plan-json" <> O.metavar "PATH" <> O.help "Use provided plan.json")
 


### PR DESCRIPTION
Adding a stackage resolver somehow fixes #1 and I don't quite know how.

The project files generated on mac and linux will still differ as before but stack will now build on the alternate platform without complaints about missing dependencies (pulling those in via the resolver I presume).