### PR TITLE
Add option to specify contents of resolver

### DIFF
--- a/src/cabal2stack.hs
+++ b/src/cabal2stack.hs
@@ -4,14 +4,11 @@
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedLabels       #-}
 {-# LANGUAGE OverloadedStrings      #-}
 {-# LANGUAGE RecordWildCards        #-}
-{-# LANGUAGE StandaloneDeriving     #-}
 {-# LANGUAGE TypeOperators          #-}
 {-# LANGUAGE UndecidableInstances   #-}
-{-# OPTIONS_GHC -Wwarn=orphans #-}
 module Main (main) where
 
 import Control.Applicative       (optional, (<**>), (<|>))
@@ -62,7 +59,7 @@ main = do
 
     S packages _pkgVers extraDeps flags gitPackages <- processUnits (P.pjUnits plan)
 
-    resolverFile <- maybe (pure (ResolverFile [] mempty)) getResolverContents optsResolverFile
+    resolverFile <- maybe (pure (ResolverFile [])) getResolverContents optsResolverFile
     let resolverContents = Set.fromList (map resolverPackageName (resolverFilePackages resolverFile))
 
     let stackYaml0 :: StackYaml
@@ -75,7 +72,7 @@ main = do
                                                    , let pkgid = P.PkgId pn ver
                                                    , not (pkgid `Set.member` resolverContents)
                                                    ]
-            , syFlags       = flags `diffFlags` resolverFileFlags resolverFile
+            , syFlags       = flags
             , syGitPackages = gitPackages
             }
 
@@ -84,13 +81,6 @@ main = do
     case optsOutput of
         "-" -> LBS.putStr (Y.encode [stackYaml])
         _   -> LBS.writeFile optsOutput (Y.encode [stackYaml])
-
-
-diffFlags :: Map P.PkgName (Map P.FlagName Bool)
-          -> Map P.PkgName (Map P.FlagName Bool)
-          -> Map P.PkgName (Map P.FlagName Bool)
-diffFlags = Map.differenceWith (\fs gs -> Just (Map.difference fs gs))
-
 
 -------------------------------------------------------------------------------
 -- options
@@ -292,16 +282,11 @@ instance Y.ToYAML StackYaml where
 data ResolverFile =
   ResolverFile
     { resolverFilePackages :: [ResolverPackage]
-    , resolverFileFlags    :: Map P.PkgName (Map P.FlagName Bool)
     }
-
-deriving instance Y.FromYAML P.PkgName
-deriving instance Y.FromYAML P.FlagName
 
 instance Y.FromYAML ResolverFile where
   parseYAML = Y.withMap "ResolverFile" $ \m -> ResolverFile
                 <$> m Y..: "packages"
-                <*> m Y..: "flags"
 
 data ResolverPackage =
   ResolverPackage


### PR DESCRIPTION
This is a quickly hacked together attempt at #4. It adds a `--resolver-file` option which expects the path to a YAML file in the format used by https://github.com/commercialhaskell/stackage-snapshots. It assumes that all such snapshots contain only Hackage packages.

As far as package names/versions go this seems to work. However there is an issue with flags: the `plan.json` contains values for all flags in the build plan, whereas the snapshot YAML file contains only a few flags (presumably those with non-default values). Thus the generated `stack.yaml` still redundantly specifies many flag values. I'm not sure how much this matters; perhaps `stack` will ignore the duplicate flag values?