### PR TITLE
Support using input yaml files as blueprints (fixes #6)

### DIFF
--- a/cabal2stack.cabal
+++ b/cabal2stack.cabal
@@ -37,8 +37,10 @@ executable cabal2stack
 
   -- other dependencies
   build-depends:
+    , aeson                  >= 2.0 && < 2.2
     , cabal-plan            ^>=0.7.2.1
     , HsYAML                ^>=0.2.1.1
+    , HsYAML-aeson          ^>=0.2.0.1
     , optics-core           ^>=0.4
     , optics-extra          ^>=0.4
     , optparse-applicative  ^>=0.17.0.0


### PR DESCRIPTION
Initial sketch for #6. 

@adamgundry the implementation might be perfectible and not exactly orthodox, but the general idea is that we can now parse an input `InputYamlFile` which is just (at its core) a JSON `Value`, and we can later use `unionWith` to "overlay" the `cabal2stack` content into the input yaml file.

This can be used to mutate an existing `stack.yaml` while retaining fields which don't have a direct translation (like the `nix` stuff, for example).

What's unclear is how to fix the original issue around #6 -- i.e. given:

```
package somelocalpackage
    ghc-options: -Wall
```

Now the only way to have that into the target `stack.yaml` (without `cabal2stack` performing a direct translation) would be to have the stack equivalent into the blueprint `stack.yaml` to begin with, but that would defeat the point, right? (i.e. now both the `cabal.project` and the `stack.yaml` are "source of truths" and both contains key information). Or have I misunderstood how we are planning to use this new feature?

I think this feature is valuable regardless, but perhaps we should consider extending `cabal2stack` such that it can do direct translation of some important `cabal.project` fields which we cannot derive from the `plan.json`?


